### PR TITLE
Add link to image on Docker Hub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Net Tools
 
 An image for interactive network diagnostics.
+
+https://hub.docker.com/r/faithlife/nettools/


### PR DESCRIPTION
I can see future developers who don't know about our Docker Hub organization wondering how to get this image.